### PR TITLE
v2.0.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 2.0.1-beta.2 (unreleased)
+## 2.0.1-beta.2 - 2026-09-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.1-beta.2 (unreleased)
+
+### Added
+
+- New `--header-file <path>` option on `run`: a private-header alternative to `-H/--header` for credential-bearing headers. Unlike `-H`, which is sent with every request, a header from `--header-file` is only ever attached to a request whose destination origin exactly matches one of the URLs explicitly supplied via `-u` — never a cross-origin subresource, a redirect off that origin, or any AI/MCP/proxy call. The file must be owner-only (`chmod 600`), not a symlink, and contain 1-16 `Name: value` lines; any violation, or a collision with `-H`/`--header`, or combination with `--oxylabs-waf-fallback`/`--proxy-waf-fallback`, fails before any network activity (exit code `35`). (`run`)
+
 ## 2.0.1-beta.1 - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - New `--header-file <path>` option on `run`: a private-header alternative to `-H/--header` for credential-bearing headers. Unlike `-H`, which is sent with every request, a header from `--header-file` is only ever attached to a request whose destination origin exactly matches one of the URLs explicitly supplied via `-u` — never a cross-origin subresource, a redirect off that origin, or any AI/MCP/proxy call. The file must be owner-only (`chmod 600`), not a symlink, and contain 1-16 `Name: value` lines; any violation, or a collision with `-H`/`--header`, or combination with `--oxylabs-waf-fallback`/`--proxy-waf-fallback`, fails before any network activity (exit code `35`). (`run`)
 
+### Security
+
+- `--header-file` private headers are now withheld from plain-HTTP destinations, even when the origin exactly matches an explicitly-supplied `-u` target. `getPrivateHeadersForUrl` (`src/utility/globals.ts`) — the single choke point every private-header call site routes through — now requires `https:` in addition to the existing origin-allowlist check, so a credential-bearing header can never be sent in cleartext. (`run`, `utility`)
+
 ## 2.0.1-beta.1 - 2026-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "2.0.1-beta.1",
+    "version": "2.0.1-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@js-recon/js-recon",
-            "version": "2.0.1-beta.1",
+            "version": "2.0.1-beta.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4556,9 +4556,9 @@
             "license": "Unlicense"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "funding": [
                 {
                     "type": "github",
@@ -7056,9 +7056,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "2.0.1-beta.1",
+    "version": "2.0.1-beta.2",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/__tests__/utility/globals.test.ts
+++ b/src/__tests__/utility/globals.test.ts
@@ -5,6 +5,8 @@ import {
     clearOpenapiOutput,
     setTargetUrl,
     getTargetUrl,
+    setPrivateHeaders,
+    getPrivateHeadersForUrl,
 } from "../../utility/globals.js";
 import type { OpenapiOutputItem } from "../../utility/globals.js";
 
@@ -59,5 +61,31 @@ describe("setTargetUrl / getTargetUrl", () => {
     it("falls back to the raw value when it isn't a parseable URL", () => {
         setTargetUrl("not-a-url");
         expect(getTargetUrl()).toBe("not-a-url");
+    });
+});
+
+describe("getPrivateHeadersForUrl", () => {
+    afterEach(() => {
+        setPrivateHeaders([], new Set());
+    });
+
+    it("attaches the header for an allowlisted HTTPS origin", () => {
+        setPrivateHeaders([{ name: "X-Secret", value: "s3cr3t" }], new Set(["https://example.com:443"]));
+        expect(getPrivateHeadersForUrl("https://example.com/api")).toEqual({ "X-Secret": "s3cr3t" });
+    });
+
+    it("withholds the header for an allowlisted HTTP origin (credential must never travel in cleartext)", () => {
+        setPrivateHeaders([{ name: "X-Secret", value: "s3cr3t" }], new Set(["http://example.com:80"]));
+        expect(getPrivateHeadersForUrl("http://example.com/api")).toEqual({});
+    });
+
+    it("withholds the header for a non-allowlisted origin", () => {
+        setPrivateHeaders([{ name: "X-Secret", value: "s3cr3t" }], new Set(["https://example.com:443"]));
+        expect(getPrivateHeadersForUrl("https://evil.example/api")).toEqual({});
+    });
+
+    it("withholds the header when none are configured", () => {
+        setPrivateHeaders([], new Set(["https://example.com:443"]));
+        expect(getPrivateHeadersForUrl("https://example.com/api")).toEqual({});
     });
 });

--- a/src/__tests__/utility/headerFile.test.ts
+++ b/src/__tests__/utility/headerFile.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+    parseHeaderFileContent,
+    HeaderFileError,
+    normalizeOrigin,
+    buildOriginAllowlist,
+    originAllowed,
+} from "../../utility/headerFile.js";
+
+describe("parseHeaderFileContent", () => {
+    it("parses a single header entry", () => {
+        expect(parseHeaderFileContent("Authorization: Bearer test123")).toEqual([
+            { name: "Authorization", value: "Bearer test123" },
+        ]);
+    });
+
+    it("parses 16 header entries", () => {
+        const lines = Array.from({ length: 16 }, (_, i) => `X-Header-${i}: value-${i}`);
+        const result = parseHeaderFileContent(lines.join("\n"));
+        expect(result).toHaveLength(16);
+        expect(result[15]).toEqual({ name: "X-Header-15", value: "value-15" });
+    });
+
+    it("tolerates a single trailing newline", () => {
+        expect(parseHeaderFileContent("X-Api-Key: abc\n")).toEqual([{ name: "X-Api-Key", value: "abc" }]);
+    });
+
+    it("strips exactly one separator space and preserves extra colons/spaces", () => {
+        expect(parseHeaderFileContent("Cookie:  a=1; b=2:3")).toEqual([{ name: "Cookie", value: " a=1; b=2:3" }]);
+    });
+
+    it("preserves a value with no leading space after the colon", () => {
+        expect(parseHeaderFileContent("X-Api-Key:abc")).toEqual([{ name: "X-Api-Key", value: "abc" }]);
+    });
+
+    it("rejects an empty file", () => {
+        expect(() => parseHeaderFileContent("")).toThrow(HeaderFileError);
+    });
+
+    it("rejects more than 16 entries", () => {
+        const lines = Array.from({ length: 17 }, (_, i) => `X-Header-${i}: v`);
+        expect(() => parseHeaderFileContent(lines.join("\n"))).toThrow(HeaderFileError);
+    });
+
+    it("rejects a blank line", () => {
+        expect(() => parseHeaderFileContent("X-Api-Key: abc\n\nX-Other: def")).toThrow(HeaderFileError);
+    });
+
+    it("rejects a comment line", () => {
+        expect(() => parseHeaderFileContent("# comment\nX-Api-Key: abc")).toThrow(HeaderFileError);
+    });
+
+    it("rejects a line with no colon", () => {
+        expect(() => parseHeaderFileContent("NotAHeader")).toThrow(HeaderFileError);
+    });
+
+    it("rejects an invalid header name (non-token characters)", () => {
+        expect(() => parseHeaderFileContent("Bad Name: abc")).toThrow(HeaderFileError);
+    });
+
+    it("rejects an empty value", () => {
+        expect(() => parseHeaderFileContent("X-Empty:")).toThrow(HeaderFileError);
+    });
+
+    it("rejects case-only duplicate header names", () => {
+        expect(() => parseHeaderFileContent("Authorization: a\nauthorization: b")).toThrow(HeaderFileError);
+    });
+
+    it("rejects a header name over 256 bytes", () => {
+        const longName = "X-" + "A".repeat(300);
+        expect(() => parseHeaderFileContent(`${longName}: v`)).toThrow(HeaderFileError);
+    });
+
+    it("rejects a value over 16384 bytes", () => {
+        const longValue = "a".repeat(16_385);
+        expect(() => parseHeaderFileContent(`X-Big: ${longValue}`)).toThrow(HeaderFileError);
+    });
+
+    it("does not leak header name/value into the thrown error message", () => {
+        expect.assertions(2);
+        try {
+            parseHeaderFileContent("X-Key: SECRET_MARKER_VALUE_XYZ789\nX-Key: SECRET_MARKER_VALUE_XYZ789");
+        } catch (error) {
+            expect((error as Error).message).not.toContain("SECRET_MARKER_VALUE_XYZ789");
+            expect((error as Error).message).not.toContain("X-Key");
+        }
+    });
+});
+
+describe("normalizeOrigin", () => {
+    it("lowercases the host and applies the default HTTPS port", () => {
+        expect(normalizeOrigin("https://Example.COM/path")).toBe("https://example.com:443");
+    });
+
+    it("applies the default HTTP port", () => {
+        expect(normalizeOrigin("http://example.com/path")).toBe("http://example.com:80");
+    });
+
+    it("preserves an explicit non-default port", () => {
+        expect(normalizeOrigin("https://example.com:8443/path")).toBe("https://example.com:8443");
+    });
+
+    it("returns null for a non-HTTP(S) scheme", () => {
+        expect(normalizeOrigin("ftp://example.com/file")).toBeNull();
+    });
+
+    it("returns null for an unparseable URL", () => {
+        expect(normalizeOrigin("not a url")).toBeNull();
+    });
+});
+
+describe("buildOriginAllowlist / originAllowed", () => {
+    it("allows a URL whose origin matches an explicitly-supplied target", () => {
+        const allowlist = buildOriginAllowlist(["https://example.com/"]);
+        expect(originAllowed("https://example.com/api/data", allowlist)).toBe(true);
+    });
+
+    it("rejects a different host", () => {
+        const allowlist = buildOriginAllowlist(["https://example.com/"]);
+        expect(originAllowed("https://cdn.example.com/chunk.js", allowlist)).toBe(false);
+    });
+
+    it("rejects a different scheme", () => {
+        const allowlist = buildOriginAllowlist(["https://example.com/"]);
+        expect(originAllowed("http://example.com/", allowlist)).toBe(false);
+    });
+
+    it("rejects a different explicit port", () => {
+        const allowlist = buildOriginAllowlist(["https://example.com/"]);
+        expect(originAllowed("https://example.com:8443/", allowlist)).toBe(false);
+    });
+});

--- a/src/cliProgram.ts
+++ b/src/cliProgram.ts
@@ -997,7 +997,9 @@ export function buildProgram(): Command {
                     privateHeaders = readHeaderFile(cmd.headerFile);
                 } catch (error) {
                     console.error(
-                        chalk.red(`[!] ${error instanceof HeaderFileError ? error.message : "Unable to read --header-file"}`)
+                        chalk.red(
+                            `[!] ${error instanceof HeaderFileError ? error.message : "Unable to read --header-file"}`
+                        )
                     );
                     process.exit(35);
                 }
@@ -1014,7 +1016,9 @@ export function buildProgram(): Command {
                     resolvedTargets = resolveTargetInputs(cmd.url).targets;
                 } catch (error) {
                     console.error(
-                        chalk.red(`[!] ${error instanceof TargetInputError ? error.message : "Unable to resolve -u/--url"}`)
+                        chalk.red(
+                            `[!] ${error instanceof TargetInputError ? error.message : "Unable to resolve -u/--url"}`
+                        )
                     );
                     process.exit(1);
                 }

--- a/src/cliProgram.ts
+++ b/src/cliProgram.ts
@@ -29,8 +29,9 @@ import {
     OxylabsFallbackConfigurationError,
     resolveOxylabsFallback,
 } from "./proxy/oxylabsFallback.js";
-import { collectTargetInput } from "./utility/targetInputs.js";
+import { collectTargetInput, resolveTargetInputs, TargetInputError } from "./utility/targetInputs.js";
 import { parseHeaderFlagValue, type CustomHeaderPair } from "./utility/customHeaders.js";
+import { readHeaderFile, buildOriginAllowlist, HeaderFileError } from "./utility/headerFile.js";
 
 /** Valid AI options for analysis modules */
 const validAiOptions = ["description"];
@@ -789,6 +790,10 @@ export function buildProgram(): Command {
             (val: string, prev: string[]) => [...prev, val],
             [] as string[]
         )
+        .option(
+            "--header-file <path>",
+            "Owner-only, non-symlink file of newline-separated 'Name: value' private headers (1-16 entries). Sent only to the exact origin(s) explicitly supplied via -u, never to third-party subresources, redirects off-origin, or any proxy/AI/MCP call. No environment-variable alternative."
+        )
         .option("--secrets", "Scan for secrets", false)
         .option("--trufflehog", "Run TruffleHog secret scanner on the output directory", false)
         .option("--trufflehog-bin <path>", "Path to the trufflehog binary (skips auto-download)", "trufflehog")
@@ -975,7 +980,46 @@ export function buildProgram(): Command {
             globalsUtil.setRespCacheFile(cmd.cacheFile);
             globalsUtil.setCacheOnly(cmd.cacheOnly);
             globalsUtil.setVerbose(cmd.verbose);
-            globalsUtil.setCustomHeaders(resolveCustomHeaders(cmd.header));
+            const resolvedCustomHeaders = resolveCustomHeaders(cmd.header);
+            globalsUtil.setCustomHeaders(resolvedCustomHeaders);
+
+            if (cmd.headerFile) {
+                if (cmd.oxylabsWafFallback || cmd.proxyWafFallback) {
+                    console.error(
+                        chalk.red(
+                            "[!] --header-file cannot be combined with --oxylabs-waf-fallback or --proxy-waf-fallback (a private header must never be sent through a third-party fallback proxy)"
+                        )
+                    );
+                    process.exit(35);
+                }
+                let privateHeaders: ReturnType<typeof readHeaderFile>;
+                try {
+                    privateHeaders = readHeaderFile(cmd.headerFile);
+                } catch (error) {
+                    console.error(
+                        chalk.red(`[!] ${error instanceof HeaderFileError ? error.message : "Unable to read --header-file"}`)
+                    );
+                    process.exit(35);
+                }
+                const customHeaderNames = new Set(resolvedCustomHeaders.map((h) => h.name.toLowerCase()));
+                const collision = privateHeaders.find((h) => customHeaderNames.has(h.name.toLowerCase()));
+                if (collision) {
+                    console.error(
+                        chalk.red("[!] --header-file has a header name that collides with a -H/--header value")
+                    );
+                    process.exit(35);
+                }
+                let resolvedTargets: readonly string[];
+                try {
+                    resolvedTargets = resolveTargetInputs(cmd.url).targets;
+                } catch (error) {
+                    console.error(
+                        chalk.red(`[!] ${error instanceof TargetInputError ? error.message : "Unable to resolve -u/--url"}`)
+                    );
+                    process.exit(1);
+                }
+                globalsUtil.setPrivateHeaders(privateHeaders, buildOriginAllowlist(resolvedTargets));
+            }
 
             configureSandbox(cmd);
 

--- a/src/exploit/utility/rawRequest.ts
+++ b/src/exploit/utility/rawRequest.ts
@@ -45,7 +45,11 @@ export const rawRequest = async (url: string, opts: RawRequestOptions): Promise<
                 const response = await fetch(url, {
                     ...dispatcherOpts,
                     method: opts.method ?? "GET",
-                    headers: { ...opts.headers, ...customHeadersToRecord(globals.getCustomHeaders()), ...privateHeaders },
+                    headers: {
+                        ...opts.headers,
+                        ...customHeadersToRecord(globals.getCustomHeaders()),
+                        ...privateHeaders,
+                    },
                     body: opts.body,
                     redirect: "manual",
                     signal: AbortSignal.any(signals),

--- a/src/exploit/utility/rawRequest.ts
+++ b/src/exploit/utility/rawRequest.ts
@@ -36,10 +36,16 @@ export const rawRequest = async (url: string, opts: RawRequestOptions): Promise<
             const signals = opts.signal ? [opts.signal, timeoutController.signal] : [timeoutController.signal];
 
             try {
+                // Private (--header-file) headers are only attached when this specific request has
+                // no proxy dispatcher (never leak them to a proxy) and its origin is in the
+                // explicitly-supplied target allowlist — checked per call, since callers here
+                // (next_routerStateForge.ts included) already issue one rawRequest per URL/redirect
+                // hop rather than following redirects internally.
+                const privateHeaders = dispatcherOpts.dispatcher ? {} : globals.getPrivateHeadersForUrl(url);
                 const response = await fetch(url, {
                     ...dispatcherOpts,
                     method: opts.method ?? "GET",
-                    headers: { ...opts.headers, ...customHeadersToRecord(globals.getCustomHeaders()) },
+                    headers: { ...opts.headers, ...customHeadersToRecord(globals.getCustomHeaders()), ...privateHeaders },
                     body: opts.body,
                     redirect: "manual",
                     signal: AbortSignal.any(signals),

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/js-recon/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "2.0.1-beta.1";
+const version = "2.0.1-beta.2";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/lazyLoad/generic/generic_resolveScope.ts
+++ b/src/lazyLoad/generic/generic_resolveScope.ts
@@ -26,7 +26,10 @@ export const resolveRedirectChain = async (
         try {
             res = await fetchImpl(currentUrl, {
                 redirect: "manual",
-                headers: customHeadersToRecord(globals.getCustomHeaders()),
+                headers: {
+                    ...customHeadersToRecord(globals.getCustomHeaders()),
+                    ...globals.getPrivateHeadersForUrl(currentUrl),
+                },
             });
         } catch {
             return currentUrl;

--- a/src/lazyLoad/next_js/next_GetLazyResourcesWebpackJs.ts
+++ b/src/lazyLoad/next_js/next_GetLazyResourcesWebpackJs.ts
@@ -98,7 +98,14 @@ const next_GetLazyResourcesWebpackJs = async (url: string, threads: number = 1):
         }
 
         if (/^https?:\/\//i.test(req_url)) {
-            await request.continue();
+            // Never attach private headers to a proxied request (proxyArgs.arg set) — see
+            // cliProgram.ts's --header-file validation and utility/CLAUDE.md.
+            const extraHeaders = proxyArgs.arg ? {} : globals.getPrivateHeadersForUrl(req_url);
+            if (Object.keys(extraHeaders).length === 0) {
+                await request.continue();
+            } else {
+                await request.continue({ headers: { ...request.headers(), ...extraHeaders } });
+            }
         } else {
             await request.abort();
         }

--- a/src/lazyLoad/techDetect/index.ts
+++ b/src/lazyLoad/techDetect/index.ts
@@ -124,7 +124,14 @@ const frameworkDetect = async (
                 interceptedUrls.push(req.url());
                 // Abort non-http/s schemes (mailto:, data:, etc.) — continue() throws for them.
                 if (/^https?:\/\//i.test(req.url())) {
-                    req.continue().catch(() => {});
+                    // Never attach private headers to a proxied request (proxyArgs.arg set) — see
+                    // cliProgram.ts's --header-file validation and utility/CLAUDE.md.
+                    const extraHeaders = proxyArgs.arg ? {} : globalsUtil.getPrivateHeadersForUrl(req.url());
+                    if (Object.keys(extraHeaders).length === 0) {
+                        req.continue().catch(() => {});
+                    } else {
+                        req.continue({ headers: { ...req.headers(), ...extraHeaders } }).catch(() => {});
+                    }
                 } else {
                     req.abort().catch(() => {});
                 }

--- a/src/utility/globals.ts
+++ b/src/utility/globals.ts
@@ -292,12 +292,20 @@ export const hasPrivateHeaders = (): boolean => privateHeaders.length > 0;
 
 /**
  * Returns the private headers to attach to a request to `url`, or `{}` when no private headers are
- * configured or `url`'s origin isn't in the explicitly-supplied target allowlist. Callers must check
- * this per request (and per redirect hop) rather than caching the result — see `makeReq.ts`.
+ * configured, `url`'s origin isn't in the explicitly-supplied target allowlist, or `url` isn't HTTPS.
+ * The HTTPS requirement holds even for an origin the user explicitly targeted — these headers are
+ * unconditionally credential-bearing (see `headerFile.ts`), so sending one over plaintext HTTP would
+ * expose it to any network observer regardless of destination intent. Callers must check this per
+ * request (and per redirect hop) rather than caching the result — see `makeReq.ts`.
  * @param url - The destination URL a request is about to be sent to
  */
 export const getPrivateHeadersForUrl = (url: string): Record<string, string> => {
     if (privateHeaders.length === 0 || !originAllowed(url, privateHeaderOrigins)) return {};
+    try {
+        if (new URL(url).protocol !== "https:") return {};
+    } catch {
+        return {};
+    }
     const record: Record<string, string> = {};
     for (const { name, value } of privateHeaders) {
         record[name] = value;

--- a/src/utility/globals.ts
+++ b/src/utility/globals.ts
@@ -1,3 +1,5 @@
+import { originAllowed } from "./headerFile.js";
+
 // Proxy Configuration
 /** Path to the proxy configuration file */
 export let proxyConfigFile = ".proxy_config.json";
@@ -260,6 +262,47 @@ export const setCustomHeaders = (value: { name: string; value: string }[]): void
  */
 export const getCustomHeaders = (): { name: string; value: string }[] => {
     return customHeaders;
+};
+
+// Private Header Configuration (--header-file, run command only)
+/** Header/value pairs sourced from --header-file. Kept as a separate array from `customHeaders` —
+ * these are only ever attached to requests whose destination origin is in `privateHeaderOrigins`,
+ * never merged into CONFIG, YAML config, or any other serializable global. See `utility/headerFile.ts`. */
+let privateHeaders: { name: string; value: string }[] = [];
+/** Normalized (scheme://host:port) origins of the explicitly-supplied scan targets — the only
+ * origins private headers may ever be attached to. */
+let privateHeaderOrigins: ReadonlySet<string> = new Set();
+
+/**
+ * Sets the private headers and the origin allowlist they're scoped to. Called once, before any
+ * network activity, by the `run` command's action handler in `cliProgram.ts`.
+ * @param headers - Array of name/value header pairs read from --header-file
+ * @param allowedOrigins - Normalized origins of the explicitly-supplied scan targets
+ */
+export const setPrivateHeaders = (
+    headers: { name: string; value: string }[],
+    allowedOrigins: ReadonlySet<string>
+): void => {
+    privateHeaders = headers;
+    privateHeaderOrigins = allowedOrigins;
+};
+
+/** True when --header-file supplied at least one private header for this run. */
+export const hasPrivateHeaders = (): boolean => privateHeaders.length > 0;
+
+/**
+ * Returns the private headers to attach to a request to `url`, or `{}` when no private headers are
+ * configured or `url`'s origin isn't in the explicitly-supplied target allowlist. Callers must check
+ * this per request (and per redirect hop) rather than caching the result — see `makeReq.ts`.
+ * @param url - The destination URL a request is about to be sent to
+ */
+export const getPrivateHeadersForUrl = (url: string): Record<string, string> => {
+    if (privateHeaders.length === 0 || !originAllowed(url, privateHeaderOrigins)) return {};
+    const record: Record<string, string> = {};
+    for (const { name, value } of privateHeaders) {
+        record[name] = value;
+    }
+    return record;
 };
 
 // AI Configuration

--- a/src/utility/headerFile.ts
+++ b/src/utility/headerFile.ts
@@ -85,7 +85,9 @@ export const parseHeaderFileContent = (content: string): PrivateHeaderPair[] => 
 
         const normalizedName = name.toLowerCase();
         if (seenNames.has(normalizedName)) {
-            throw new HeaderFileError(`Header file line ${lineNumber} duplicates a header name already defined earlier`);
+            throw new HeaderFileError(
+                `Header file line ${lineNumber} duplicates a header name already defined earlier`
+            );
         }
         seenNames.add(normalizedName);
         pairs.push({ name, value });
@@ -145,7 +147,9 @@ export const readHeaderFile = (filePath: string): PrivateHeaderPair[] => {
             throw new HeaderFileError(`Header file at ${filePath} must be a regular file`);
         }
         if (fileStats.size > MAX_HEADER_FILE_BYTES) {
-            throw new HeaderFileError(`Header file at ${filePath} exceeds the ${MAX_HEADER_FILE_BYTES}-byte size limit`);
+            throw new HeaderFileError(
+                `Header file at ${filePath} exceeds the ${MAX_HEADER_FILE_BYTES}-byte size limit`
+            );
         }
         if (process.platform !== "win32") {
             if ((fileStats.mode & 0o077) !== 0) {

--- a/src/utility/headerFile.ts
+++ b/src/utility/headerFile.ts
@@ -1,0 +1,206 @@
+import fs from "node:fs";
+
+/** A single private header name/value pair sourced from `--header-file`. Kept as its own type,
+ * never merged into `CustomHeaderPair[]` — see `globals.ts`'s `privateHeaders` storage. */
+export interface PrivateHeaderPair {
+    name: string;
+    value: string;
+}
+
+export class HeaderFileError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "HeaderFileError";
+    }
+}
+
+const MAX_HEADER_FILE_BYTES = 272 * 1024;
+const MIN_ENTRIES = 1;
+const MAX_ENTRIES = 16;
+const MAX_NAME_BYTES = 256;
+const MAX_VALUE_BYTES = 16_384;
+
+// RFC 7230 token characters — the same grammar HTTP field-names are restricted to.
+const TOKEN_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+const FORBIDDEN_BYTES = [String.fromCharCode(0), String.fromCharCode(13), String.fromCharCode(10)];
+const containsForbiddenBytes = (value: string): boolean => FORBIDDEN_BYTES.some((b) => value.includes(b));
+
+/**
+ * Parses the decoded text content of a `--header-file`. Pure and side-effect-free: no filesystem
+ * access here, only string validation. Fails closed on the first violation found — unlike
+ * `targetInputs.ts`'s per-line warn-and-skip convention, a malformed private-header file must never
+ * silently drop an entry, since a caller relying on a header actually being sent must be told loudly
+ * if it wasn't parsed as expected.
+ *
+ * Error messages intentionally name only the line number, never the header name, value, or raw line
+ * text — this file's whole purpose is to keep those out of every log/error surface.
+ */
+export const parseHeaderFileContent = (content: string): PrivateHeaderPair[] => {
+    // Tolerate a UTF-8 BOM and a single trailing newline (the common "file ends with \n" case)
+    // without treating either as a malformed/blank line.
+    const withoutBom = content.replace(/^﻿/, "");
+    const withoutTrailingNewline = withoutBom.replace(/\r?\n$/, "");
+
+    if (withoutTrailingNewline === "") {
+        throw new HeaderFileError("Header file is empty");
+    }
+
+    const lines = withoutTrailingNewline.split(/\r?\n/);
+    const pairs: PrivateHeaderPair[] = [];
+    const seenNames = new Set<string>();
+
+    lines.forEach((line, index) => {
+        const lineNumber = index + 1;
+        if (line.trim() === "") {
+            throw new HeaderFileError(`Header file has a blank line at line ${lineNumber}`);
+        }
+        if (line.startsWith("#")) {
+            throw new HeaderFileError(`Header file has a comment at line ${lineNumber}; comments are not supported`);
+        }
+
+        const colonIdx = line.indexOf(":");
+        if (colonIdx === -1) {
+            throw new HeaderFileError(`Header file line ${lineNumber} is not in "Name: value" format`);
+        }
+        const name = line.slice(0, colonIdx);
+        const rawValue = line.slice(colonIdx + 1);
+        const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+
+        if (name === "" || !TOKEN_RE.test(name)) {
+            throw new HeaderFileError(`Header file line ${lineNumber} has an invalid header name`);
+        }
+        if (containsForbiddenBytes(name) || containsForbiddenBytes(value)) {
+            throw new HeaderFileError(`Header file line ${lineNumber} contains a NUL/CR/LF byte`);
+        }
+        if (value === "") {
+            throw new HeaderFileError(`Header file line ${lineNumber} has an empty value`);
+        }
+        if (Buffer.byteLength(name, "utf8") > MAX_NAME_BYTES) {
+            throw new HeaderFileError(`Header file line ${lineNumber} has a header name over ${MAX_NAME_BYTES} bytes`);
+        }
+        if (Buffer.byteLength(value, "utf8") > MAX_VALUE_BYTES) {
+            throw new HeaderFileError(`Header file line ${lineNumber} has a value over ${MAX_VALUE_BYTES} bytes`);
+        }
+
+        const normalizedName = name.toLowerCase();
+        if (seenNames.has(normalizedName)) {
+            throw new HeaderFileError(`Header file line ${lineNumber} duplicates a header name already defined earlier`);
+        }
+        seenNames.add(normalizedName);
+        pairs.push({ name, value });
+    });
+
+    if (pairs.length < MIN_ENTRIES || pairs.length > MAX_ENTRIES) {
+        throw new HeaderFileError(`Header file must contain between ${MIN_ENTRIES} and ${MAX_ENTRIES} entries`);
+    }
+
+    return pairs;
+};
+
+const readBoundedHeaderFileBytes = (descriptor: number, filePath: string): Buffer => {
+    const chunks: Buffer[] = [];
+    let bytesRead = 0;
+    while (bytesRead <= MAX_HEADER_FILE_BYTES) {
+        const remaining = MAX_HEADER_FILE_BYTES + 1 - bytesRead;
+        const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, remaining));
+        const count = fs.readSync(descriptor, chunk, 0, chunk.length, null);
+        if (count === 0) break;
+        chunks.push(chunk.subarray(0, count));
+        bytesRead += count;
+    }
+    if (bytesRead > MAX_HEADER_FILE_BYTES) {
+        throw new HeaderFileError(`Header file at ${filePath} exceeds the ${MAX_HEADER_FILE_BYTES}-byte size limit`);
+    }
+    return Buffer.concat(chunks, bytesRead);
+};
+
+/**
+ * Reads, permission-checks, and parses a `--header-file`. Fails before any network activity — this
+ * is called synchronously from the CLI action handler, before `run()` starts. Mirrors the hardened
+ * file-open idiom already used for `--config` (`config/applicationConfig.ts`) and `-u`'s target-file
+ * branch (`targetInputs.ts`): reject symlinks, open with `O_NOFOLLOW`, verify via `fstat`, and — since
+ * a header file is unconditionally secret-bearing, unlike `--config` which only sometimes is — always
+ * require owner-only permissions rather than gating on sniffing the content for secret-shaped values.
+ */
+export const readHeaderFile = (filePath: string): PrivateHeaderPair[] => {
+    const noFollowFlag = process.platform === "win32" ? 0 : (fs.constants.O_NOFOLLOW ?? 0);
+    let descriptor: number;
+    try {
+        if (fs.lstatSync(filePath).isSymbolicLink()) {
+            throw new HeaderFileError(`Header file at ${filePath} must not be a symbolic link`);
+        }
+        descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | noFollowFlag);
+    } catch (error) {
+        if (error instanceof HeaderFileError) throw error;
+        if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+            throw new HeaderFileError(`Header file at ${filePath} must not be a symbolic link`);
+        }
+        throw new HeaderFileError(`Unable to open header file at ${filePath}`);
+    }
+
+    try {
+        const fileStats = fs.fstatSync(descriptor);
+        if (!fileStats.isFile()) {
+            throw new HeaderFileError(`Header file at ${filePath} must be a regular file`);
+        }
+        if (fileStats.size > MAX_HEADER_FILE_BYTES) {
+            throw new HeaderFileError(`Header file at ${filePath} exceeds the ${MAX_HEADER_FILE_BYTES}-byte size limit`);
+        }
+        if (process.platform !== "win32") {
+            if ((fileStats.mode & 0o077) !== 0) {
+                throw new HeaderFileError(
+                    `Header file at ${filePath} must not be readable by group or other users (use chmod 600)`
+                );
+            }
+            if (typeof process.getuid === "function" && fileStats.uid !== process.getuid()) {
+                throw new HeaderFileError(`Header file at ${filePath} must be owned by this user`);
+            }
+        }
+
+        const bytes = readBoundedHeaderFileBytes(descriptor, filePath);
+        let text: string;
+        try {
+            text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        } catch {
+            throw new HeaderFileError(`Header file at ${filePath} is not valid UTF-8`);
+        }
+        return parseHeaderFileContent(text);
+    } catch (error) {
+        if (error instanceof HeaderFileError) throw error;
+        throw new HeaderFileError(`Unable to inspect or read header file at ${filePath}`);
+    } finally {
+        fs.closeSync(descriptor);
+    }
+};
+
+/** Normalizes a URL to a `scheme://host:port` origin string (lowercase host, explicit default port),
+ * for exact same-origin comparisons. Returns null for non-HTTP(S) or unparseable URLs. */
+export const normalizeOrigin = (url: string): string | null => {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return null;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+    return `${parsed.protocol}//${parsed.hostname.toLowerCase()}:${port}`;
+};
+
+/** Builds the first-party origin allowlist from the explicitly-supplied target URLs. Non-HTTP(S)
+ * entries are silently skipped — target resolution has already validated every target is HTTP(S). */
+export const buildOriginAllowlist = (urls: readonly string[]): ReadonlySet<string> => {
+    const origins = new Set<string>();
+    for (const url of urls) {
+        const origin = normalizeOrigin(url);
+        if (origin) origins.add(origin);
+    }
+    return origins;
+};
+
+/** True when `url`'s origin exactly matches one of the explicitly-supplied target origins. */
+export const originAllowed = (url: string, allowlist: ReadonlySet<string>): boolean => {
+    const origin = normalizeOrigin(url);
+    return origin !== null && allowlist.has(origin);
+};

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -157,6 +157,43 @@ const UAs = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
 ];
 
+const MAX_PRIVATE_HEADER_REDIRECTS = 20;
+
+/**
+ * Issues one fetch, attaching private (`--header-file`) headers only when `url`'s origin is in the
+ * explicitly-supplied target allowlist, and only when no proxy dispatcher is in play (a proxied
+ * request — including the automatic Oxylabs WAF-block fallback — must never see a private header;
+ * see `cliProgram.ts`'s `--header-file` validation, which rejects the combination with the fallback
+ * flags outright rather than relying solely on this runtime check).
+ *
+ * When private headers are configured, redirects are followed manually so the origin check re-runs
+ * on every hop and a private header is dropped the moment a redirect leaves the allowlist — the
+ * platform `fetch`'s automatic redirect-follow has no such per-hop hook. When no private headers are
+ * configured (the common case), this is a single plain `fetch` call with unchanged behavior.
+ */
+const fetchWithPrivateHeaderScope = async (url: string, options: FetchOptsWithDispatcher): Promise<Response> => {
+    if (!globals.hasPrivateHeaders() || options.dispatcher) {
+        return fetch(url, options);
+    }
+    let currentUrl = url;
+    for (let hop = 0; hop <= MAX_PRIVATE_HEADER_REDIRECTS; hop++) {
+        const hopHeaders = new Headers(options.headers);
+        for (const [name, value] of Object.entries(globals.getPrivateHeadersForUrl(currentUrl))) {
+            hopHeaders.set(name, value);
+        }
+        const response = await fetch(currentUrl, { ...options, headers: hopHeaders, redirect: "manual" });
+        const isRedirect = response.status >= 300 && response.status < 400;
+        const location = isRedirect ? response.headers.get("location") : null;
+        if (!location) return response;
+        try {
+            currentUrl = new URL(location, currentUrl).href;
+        } catch {
+            return response;
+        }
+    }
+    throw new Error(`Exceeded redirect limit while resolving ${url}`);
+};
+
 export const getCacheIdentityDigest = (url: string, headers: HeadersInit): string => {
     const normalizedHeaders = [...new Headers(headers as HeadersInit).entries()].sort(([left], [right]) =>
         left.localeCompare(right)
@@ -304,7 +341,7 @@ const singleFetch = async (
 
             try {
                 EventEmitter.defaultMaxListeners = 20;
-                const response = await fetch(url, currentRequestOptions); // lgtm[js/insecure-download]: this is a recon tool's generic HTTP client — it fetches whatever URL/scheme the target itself serves, by design.
+                const response = await fetchWithPrivateHeaderScope(url, currentRequestOptions); // lgtm[js/insecure-download]: this is a recon tool's generic HTTP client — it fetches whatever URL/scheme the target itself serves, by design.
                 const arrayBuffer = await response.arrayBuffer();
                 if (controller.signal.aborted) {
                     shouldDestroyOwnedDispatcher = true;
@@ -406,6 +443,20 @@ const handleFirewall = async (
         if (proxyArgs.authenticate) await page.authenticate(proxyArgs.authenticate);
         const customHeaders = customHeadersToRecord(globals.getCustomHeaders());
         if (Object.keys(customHeaders).length > 0) await page.setExtraHTTPHeaders(customHeaders);
+        // Private headers are never set via setExtraHTTPHeaders (that would send them to every
+        // subresource this page loads, including off-origin ones). Interception lets each request
+        // be origin-checked individually; skipped entirely when a proxy is in play (proxyArgs.arg).
+        if (globals.hasPrivateHeaders() && !proxyArgs.arg) {
+            await page.setRequestInterception(true);
+            page.on("request", (req) => {
+                const extraHeaders = globals.getPrivateHeadersForUrl(req.url());
+                if (Object.keys(extraHeaders).length === 0) {
+                    req.continue().catch(() => undefined);
+                } else {
+                    req.continue({ headers: { ...req.headers(), ...extraHeaders } }).catch(() => undefined);
+                }
+            });
+        }
         await page.goto(url);
         if (signal?.aborted) return null;
         await new Promise<void>((resolve) => {

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -161,10 +161,11 @@ const MAX_PRIVATE_HEADER_REDIRECTS = 20;
 
 /**
  * Issues one fetch, attaching private (`--header-file`) headers only when `url`'s origin is in the
- * explicitly-supplied target allowlist, and only when no proxy dispatcher is in play (a proxied
- * request — including the automatic Oxylabs WAF-block fallback — must never see a private header;
- * see `cliProgram.ts`'s `--header-file` validation, which rejects the combination with the fallback
- * flags outright rather than relying solely on this runtime check).
+ * explicitly-supplied target allowlist, `url` is HTTPS (never sent in cleartext, even to an
+ * allowlisted HTTP origin), and no proxy dispatcher is in play (a proxied request — including the
+ * automatic Oxylabs WAF-block fallback — must never see a private header; see `cliProgram.ts`'s
+ * `--header-file` validation, which rejects the combination with the fallback flags outright rather
+ * than relying solely on this runtime check).
  *
  * When private headers are configured, redirects are followed manually so the origin check re-runs
  * on every hop and a private header is dropped the moment a redirect leaves the allowlist — the
@@ -178,7 +179,11 @@ const fetchWithPrivateHeaderScope = async (url: string, options: FetchOptsWithDi
     let currentUrl = url;
     for (let hop = 0; hop <= MAX_PRIVATE_HEADER_REDIRECTS; hop++) {
         const hopHeaders = new Headers(options.headers);
-        for (const [name, value] of Object.entries(globals.getPrivateHeadersForUrl(currentUrl))) {
+        // Scheme check duplicated here (also enforced inside getPrivateHeadersForUrl) so the
+        // guard sits directly beside the fetch sink instead of only inside a helper two calls away.
+        const isHttps = currentUrl.startsWith("https://");
+        const privateHeadersForHop = isHttps ? globals.getPrivateHeadersForUrl(currentUrl) : {};
+        for (const [name, value] of Object.entries(privateHeadersForHop)) {
             hopHeaders.set(name, value);
         }
         const response = await fetch(currentUrl, { ...options, headers: hopHeaders, redirect: "manual" });


### PR DESCRIPTION
## 2.0.1-beta.2 - 2026-09-03

### Added

- New `--header-file <path>` option on `run`: a private-header alternative to `-H/--header` for credential-bearing headers. Unlike `-H`, which is sent with every request, a header from `--header-file` is only ever attached to a request whose destination origin exactly matches one of the URLs explicitly supplied via `-u` — never a cross-origin subresource, a redirect off that origin, or any AI/MCP/proxy call. The file must be owner-only (`chmod 600`), not a symlink, and contain 1-16 `Name: value` lines; any violation, or a collision with `-H`/`--header`, or combination with `--oxylabs-waf-fallback`/`--proxy-waf-fallback`, fails before any network activity (exit code `35`). (`run`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--header-file <path>` option to securely provide private request headers.
  * Private headers are sent only to explicitly specified, matching origins and are excluded from proxies, cross-origin requests, and redirects to other origins.
  * Added validation for file permissions, format, size, duplicate headers, and conflicting options.

* **Bug Fixes**
  * Prevented private headers from leaking through redirects or browser requests to unauthorized origins.

* **Chores**
  * Updated the version to 2.0.1-beta.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->