### PR TITLE
v2.0.1-beta.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: getplumber/plumber@e81ed4965fd92e0d2b63e95d399ed0419f5de2fa # v0.4.12, 2026-07-20
+      - uses: getplumber/plumber@56369e7d43c4878049ee8ec6c2d600c21af45c4e # v0.4.12, 2026-07-20
         with:
           score-push: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.1-beta.3 - (unreleased)
+
+### Security
+
+- Removed `safePath()` from `src/lazyLoad/sourcemap.ts`, an unused path-sanitization function whose single-pass `../` regex strip could leave a traversal sequence behind (CodeQL `js/incomplete-multi-character-sanitization`). The function had no callers anywhere in the codebase; the actual source-map output write path is already bounded correctly by `resolveSourceMapOutputPath()` in `src/sourcemaps/index.ts`. (`lazyload`)
+
 ## 2.0.1-beta.2 - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Changed
 
-- Bumped dependencies via Dependabot: `puppeteer`/`puppeteer-core` (Docker images, #179), the `actions/*` GitHub Actions group (#181), the npm minor/patch group covering 10 packages (#182), `inquirer` to 14.0.2 (#176), and `datatables.net-dt` to 3.0.1 (#175).
+- Bumped dependencies via Dependabot: `puppeteer`/`puppeteer-core` (Docker images, #179), the `actions/*` GitHub Actions group (#181), the npm minor/patch group covering 10 packages (#182), and `inquirer` to 14.0.2 (#176).
 - Removed the `@types/chalk` dev dependency — it's a deprecated stub package superseded by `chalk`'s own bundled type definitions (unused since the `chalk` v6 bump); nothing in `src/` referenced it (#177, closed instead of merged).
+
+### Fixed
+
+- Reverted `datatables.net-dt` back to `^2.3.8` after #175 bumped it to `3.0.1` — DataTables' styling package must match the core `datatables.net` library's major version, and `datatables.net` itself stayed on `^2.3.6`. `report`'s local asset path (`genHtml.ts`) resolves both from `node_modules`, so the mismatch would have shipped 2.x DataTables JS paired with 3.x CSS in generated HTML reports.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.0.1-beta.3 - (unreleased)
 
+### Changed
+
+- Bumped dependencies via Dependabot: `puppeteer`/`puppeteer-core` (Docker images, #179), the `actions/*` GitHub Actions group (#181), the npm minor/patch group covering 10 packages (#182), `inquirer` to 14.0.2 (#176), and `datatables.net-dt` to 3.0.1 (#175).
+- Removed the `@types/chalk` dev dependency — it's a deprecated stub package superseded by `chalk`'s own bundled type definitions (unused since the `chalk` v6 bump); nothing in `src/` referenced it (#177, closed instead of merged).
+
 ### Security
 
 - Removed `safePath()` from `src/lazyLoad/sourcemap.ts`, an unused path-sanitization function whose single-pass `../` regex strip could leave a traversal sequence behind (CodeQL `js/incomplete-multi-character-sanitization`). The function had no callers anywhere in the codebase; the actual source-map output write path is already bounded correctly by `resolveSourceMapOutputPath()` in `src/sourcemaps/index.ts`. (`lazyload`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 2.0.1-beta.3 - (unreleased)
+## 2.0.1-beta.3 - 2026-09-03
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/puppeteer/puppeteer:25.8.0
+FROM ghcr.io/puppeteer/puppeteer:25.9.0
 
 WORKDIR /home/pptruser
 # Pin HOME so path resolution (Puppeteer's Chrome cache, ~/.js-recon rules cache, etc.)

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ghcr.io/puppeteer/puppeteer:25.8.0
+FROM ghcr.io/puppeteer/puppeteer:25.9.0
 
 WORKDIR /home/pptruser
 # Pin HOME so path resolution (Puppeteer's Chrome cache, ~/.js-recon rules cache, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@anthropic-ai/sdk": "^0.117.1",
+                "@anthropic-ai/sdk": "^0.122.0",
                 "@aws-sdk/client-api-gateway": "^3.958.0",
                 "@babel/generator": "^8.0.0",
                 "@babel/parser": "^8.0.4",
@@ -79,9 +79,9 @@
             }
         },
         "node_modules/@anthropic-ai/sdk": {
-            "version": "0.117.1",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
-            "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+            "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
             "license": "MIT",
             "dependencies": {
                 "json-schema-to-ts": "^3.1.1",
@@ -100,19 +100,19 @@
             }
         },
         "node_modules/@aws-sdk/client-api-gateway": {
-            "version": "3.1110.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1110.0.tgz",
-            "integrity": "sha512-XmnTF6YGzAk/nCHjouli+KhEQORIK9h6hwUgWdTDxDAROedA6b6sBepUfFF4J5Lwn0Uavsh52/5aAnprnJmURA==",
+            "version": "3.1121.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1121.0.tgz",
+            "integrity": "sha512-3EaXrV+zT5xnZLNLCOlSvosjVZf65MRM8WuYtJEkoQsOu1MX+f53UP+v+YVURxzlWkcn5f1KkdUu1QrDrlo7SA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.7",
-                "@aws-sdk/credential-provider-node": "^3.972.79",
-                "@aws-sdk/middleware-sdk-api-gateway": "^3.972.27",
-                "@aws-sdk/types": "^3.974.3",
-                "@smithy/core": "^3.31.1",
-                "@smithy/fetch-http-handler": "^5.6.13",
-                "@smithy/node-http-handler": "^4.9.13",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/credential-provider-node": "^3.972.81",
+                "@aws-sdk/middleware-sdk-api-gateway": "^3.972.29",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -120,17 +120,17 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.977.8",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
-            "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+            "version": "3.977.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+            "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.4",
-                "@aws-sdk/xml-builder": "^3.972.39",
+                "@aws-sdk/types": "^3.974.5",
+                "@aws-sdk/xml-builder": "^3.972.40",
                 "@aws/lambda-invoke-store": "^0.3.0",
-                "@smithy/core": "^3.31.1",
+                "@smithy/core": "^3.33.3",
                 "@smithy/signature-v4": "^5.6.12",
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -139,15 +139,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.69",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
-            "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+            "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -155,17 +155,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.71",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
-            "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+            "version": "3.972.72",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+            "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/fetch-http-handler": "^5.6.13",
-                "@smithy/node-http-handler": "^4.9.13",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -173,23 +173,23 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.973.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
-            "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+            "version": "3.973.15",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+            "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/credential-provider-env": "^3.972.69",
-                "@aws-sdk/credential-provider-http": "^3.972.71",
-                "@aws-sdk/credential-provider-login": "^3.972.76",
-                "@aws-sdk/credential-provider-process": "^3.972.69",
-                "@aws-sdk/credential-provider-sso": "^3.973.13",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-                "@aws-sdk/nested-clients": "^3.997.43",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/credential-provider-env": "^3.972.70",
+                "@aws-sdk/credential-provider-http": "^3.972.72",
+                "@aws-sdk/credential-provider-login": "^3.972.77",
+                "@aws-sdk/credential-provider-process": "^3.972.70",
+                "@aws-sdk/credential-provider-sso": "^3.973.14",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
                 "@smithy/credential-provider-imds": "^4.4.16",
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -197,16 +197,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.76",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
-            "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+            "version": "3.972.77",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+            "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/nested-clients": "^3.997.43",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -214,21 +214,21 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.80",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
-            "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+            "version": "3.972.81",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+            "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.69",
-                "@aws-sdk/credential-provider-http": "^3.972.71",
-                "@aws-sdk/credential-provider-ini": "^3.973.14",
-                "@aws-sdk/credential-provider-process": "^3.972.69",
-                "@aws-sdk/credential-provider-sso": "^3.973.13",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
+                "@aws-sdk/credential-provider-env": "^3.972.70",
+                "@aws-sdk/credential-provider-http": "^3.972.72",
+                "@aws-sdk/credential-provider-ini": "^3.973.15",
+                "@aws-sdk/credential-provider-process": "^3.972.70",
+                "@aws-sdk/credential-provider-sso": "^3.973.14",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
                 "@smithy/credential-provider-imds": "^4.4.16",
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -236,15 +236,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.69",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
-            "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+            "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -252,17 +252,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.973.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
-            "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+            "version": "3.973.14",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+            "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/nested-clients": "^3.997.43",
-                "@aws-sdk/token-providers": "3.1111.0",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/token-providers": "3.1116.0",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -270,16 +270,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.75",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
-            "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+            "version": "3.972.76",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+            "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/nested-clients": "^3.997.43",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -287,14 +287,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
-            "version": "3.972.28",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.28.tgz",
-            "integrity": "sha512-4CfqA8dKTtRATsmNcGC4t3IVi0GjWyzkQgnIamx3t3i6lL7jebRPUcPTd3pwSb/TPl/qI+w1krmIZl5/dLPe/g==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.29.tgz",
+            "integrity": "sha512-1s573fHaKeBW+egKMTqgcMD9gO3SioT3PpUK4FEAMnnXbh2RwdJJxXd3mSTXymcRG85rSY/8JAsd0u0xvVaj1w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -302,18 +302,18 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.43",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
-            "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+            "version": "3.997.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+            "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.45",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/fetch-http-handler": "^5.6.13",
-                "@smithy/node-http-handler": "^4.9.13",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -321,14 +321,14 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.45",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
-            "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+            "version": "3.996.46",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+            "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.4",
+                "@aws-sdk/types": "^3.974.5",
                 "@smithy/signature-v4": "^5.6.12",
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -336,16 +336,16 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1111.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
-            "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+            "version": "3.1116.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+            "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.8",
-                "@aws-sdk/nested-clients": "^3.997.43",
-                "@aws-sdk/types": "^3.974.4",
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -353,12 +353,12 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.974.4",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
-            "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+            "version": "3.974.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+            "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -366,12 +366,12 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.39",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
-            "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+            "version": "3.972.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+            "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -573,40 +573,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@endo/cache-map": {
@@ -1661,25 +1627,6 @@
                 }
             }
         },
-        "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.3"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
         "node_modules/@noble/hashes": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1693,9 +1640,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.147.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+            "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1703,9 +1650,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
-            "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+            "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "modern-tar": "^0.8.0",
@@ -1882,10 +1829,27 @@
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
+        "node_modules/@rolldown/binding-android-arm-eabi": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+            "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+            "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1900,9 +1864,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+            "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
             "cpu": [
                 "arm64"
             ],
@@ -1917,9 +1881,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+            "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
             "cpu": [
                 "x64"
             ],
@@ -1934,9 +1898,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+            "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
             "cpu": [
                 "x64"
             ],
@@ -1951,9 +1915,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+            "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
             "cpu": [
                 "arm"
             ],
@@ -1968,13 +1932,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+            "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1985,13 +1952,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+            "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2002,13 +1972,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+            "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2019,13 +1992,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+            "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2036,13 +2012,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+            "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2053,13 +2032,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+            "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2070,9 +2052,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+            "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
             "cpu": [
                 "arm64"
             ],
@@ -2086,29 +2068,10 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+            "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
             "cpu": [
                 "arm64"
             ],
@@ -2123,9 +2086,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+            "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
             "cpu": [
                 "x64"
             ],
@@ -2282,9 +2245,9 @@
             "license": "MIT"
         },
         "node_modules/@smithy/core": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
-            "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+            "version": "3.33.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+            "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.17.2",
@@ -2323,12 +2286,12 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.11.2",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
-            "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+            "version": "4.11.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+            "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.33.2",
+                "@smithy/core": "^3.33.3",
                 "@smithy/types": "^4.17.2",
                 "tslib": "^2.6.2"
             },
@@ -2425,17 +2388,6 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@tybys/wasm-util": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
         },
         "node_modules/@types/better-sqlite3": {
             "version": "7.6.13",
@@ -2560,11 +2512,15 @@
             }
         },
         "node_modules/@types/graphql": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
-            "integrity": "sha512-UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==",
+            "version": "14.5.0",
+            "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+            "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+            "deprecated": "This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "graphql": "*"
+            }
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
@@ -2654,17 +2610,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
-            "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+            "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.67.0",
-                "@typescript-eslint/type-utils": "8.67.0",
-                "@typescript-eslint/utils": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0",
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/type-utils": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2677,7 +2633,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.67.0",
+                "@typescript-eslint/parser": "^8.68.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -2693,16 +2649,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
-            "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+            "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.67.0",
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0",
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2718,14 +2674,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
-            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+            "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.67.0",
-                "@typescript-eslint/types": "^8.67.0",
+                "@typescript-eslint/tsconfig-utils": "^8.68.0",
+                "@typescript-eslint/types": "^8.68.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2740,14 +2696,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
-            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+            "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0"
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2758,9 +2714,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
-            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+            "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2775,15 +2731,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
-            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+            "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0",
-                "@typescript-eslint/utils": "8.67.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2800,9 +2756,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
-            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+            "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2814,16 +2770,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
-            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+            "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.67.0",
-                "@typescript-eslint/tsconfig-utils": "8.67.0",
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0",
+                "@typescript-eslint/project-service": "8.68.0",
+                "@typescript-eslint/tsconfig-utils": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2842,16 +2798,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
-            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+            "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.67.0",
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0"
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2866,13 +2822,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+            "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/types": "8.68.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2884,14 +2840,14 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-            "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+            "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.10",
+                "@vitest/utils": "4.1.11",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -2905,8 +2861,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.10",
-                "vitest": "4.1.10"
+                "@vitest/browser": "4.1.11",
+                "vitest": "4.1.11"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -2915,16 +2871,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+            "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.10",
-                "@vitest/utils": "4.1.10",
+                "@vitest/spy": "4.1.11",
+                "@vitest/utils": "4.1.11",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2933,13 +2889,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+            "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.10",
+                "@vitest/spy": "4.1.11",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -2960,9 +2916,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+            "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2973,13 +2929,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+            "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.10",
+                "@vitest/utils": "4.1.11",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -2987,14 +2943,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+            "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.10",
-                "@vitest/utils": "4.1.10",
+                "@vitest/pretty-format": "4.1.11",
+                "@vitest/utils": "4.1.11",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -3003,9 +2959,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+            "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -3013,13 +2969,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+            "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.10",
+                "@vitest/pretty-format": "4.1.11",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4188,9 +4144,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+            "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -5565,9 +5521,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -5581,23 +5537,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
             "cpu": [
                 "arm64"
             ],
@@ -5616,9 +5572,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
@@ -5637,9 +5593,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
@@ -5658,9 +5614,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
@@ -5679,9 +5635,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
             "cpu": [
                 "arm"
             ],
@@ -5700,13 +5656,16 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5721,13 +5680,16 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5742,13 +5704,16 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5763,13 +5728,16 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5784,9 +5752,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
             "cpu": [
                 "arm64"
             ],
@@ -5805,9 +5773,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
             "cpu": [
                 "x64"
             ],
@@ -6314,9 +6282,9 @@
             }
         },
         "node_modules/ohash": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+            "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
             "license": "MIT"
         },
         "node_modules/ollama": {
@@ -6373,9 +6341,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-7.4.0.tgz",
-            "integrity": "sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-7.8.0.tgz",
+            "integrity": "sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=22.0.0"
@@ -6384,7 +6352,8 @@
                 "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
                 "@smithy/hash-node": ">=4.3.0 <5",
                 "@smithy/signature-v4": ">=5.4.0 <6",
-                "ws": "^8.18.0",
+                "undici": ">=5 <9",
+                "ws": "^8.21.0",
                 "zod": "^3.25 || ^4.0"
             },
             "peerDependenciesMeta": {
@@ -6395,6 +6364,9 @@
                     "optional": true
                 },
                 "@smithy/signature-v4": {
+                    "optional": true
+                },
+                "undici": {
                     "optional": true
                 },
                 "ws": {
@@ -6715,9 +6687,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "dev": true,
             "funding": [
                 {
@@ -6735,7 +6707,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -6865,17 +6837,17 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "25.7.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.7.0.tgz",
-            "integrity": "sha512-zLBIYuW66SGwY7JNqGmiqeKiM92CYOs6xPibSRBPIeYGIfM1nE/8VCE8G0fGot2EfXENC4PbhktxLrQ0EK5Thg==",
+            "version": "25.9.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.9.0.tgz",
+            "integrity": "sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "3.2.0",
+                "@puppeteer/browsers": "3.2.1",
                 "chromium-bidi": "17.0.2",
                 "devtools-protocol": "0.0.1666840",
                 "lilconfig": "^3.1.3",
-                "puppeteer-core": "25.7.0",
+                "puppeteer-core": "25.9.0",
                 "typed-query-selector": "^2.12.2"
             },
             "bin": {
@@ -6886,17 +6858,17 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "25.7.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.7.0.tgz",
-            "integrity": "sha512-wgBBj7dU5ceGyoT2PCrJpkYOhxPY8mDOmcSKZP92Cj5GgqQ3kv/UxzawnOLxiYuupe4bDf/yiQm3bzs/1nI0rQ==",
+            "version": "25.9.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
+            "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "3.2.0",
+                "@puppeteer/browsers": "3.2.1",
                 "chromium-bidi": "17.0.2",
                 "devtools-protocol": "0.0.1666840",
                 "typed-query-selector": "^2.12.2",
                 "webdriver-bidi-protocol": "0.4.2",
-                "ws": "^8.21.1"
+                "ws": "^8.21.3"
             },
             "engines": {
                 "node": ">=22.12.0"
@@ -7198,13 +7170,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+            "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.147.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -7214,21 +7186,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm-eabi": "1.2.6",
+                "@rolldown/binding-android-arm64": "1.2.6",
+                "@rolldown/binding-darwin-arm64": "1.2.6",
+                "@rolldown/binding-darwin-x64": "1.2.6",
+                "@rolldown/binding-freebsd-x64": "1.2.6",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+                "@rolldown/binding-linux-arm64-musl": "1.2.6",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+                "@rolldown/binding-linux-x64-gnu": "1.2.6",
+                "@rolldown/binding-linux-x64-musl": "1.2.6",
+                "@rolldown/binding-openharmony-arm64": "1.2.6",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+                "@rolldown/binding-win32-x64-msvc": "1.2.6"
             }
         },
         "node_modules/router": {
@@ -8070,16 +8042,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
-            "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+            "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.67.0",
-                "@typescript-eslint/parser": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0",
-                "@typescript-eslint/utils": "8.67.0"
+                "@typescript-eslint/eslint-plugin": "8.68.0",
+                "@typescript-eslint/parser": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8189,16 +8161,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+            "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "lightningcss": "^1.33.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.26",
+                "rolldown": "~1.2.4",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -8215,7 +8187,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0 || ^0.5.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -8267,19 +8239,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+            "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.10",
-                "@vitest/mocker": "4.1.10",
-                "@vitest/pretty-format": "4.1.10",
-                "@vitest/runner": "4.1.10",
-                "@vitest/snapshot": "4.1.10",
-                "@vitest/spy": "4.1.10",
-                "@vitest/utils": "4.1.10",
+                "@vitest/expect": "4.1.11",
+                "@vitest/mocker": "4.1.11",
+                "@vitest/pretty-format": "4.1.11",
+                "@vitest/runner": "4.1.11",
+                "@vitest/snapshot": "4.1.11",
+                "@vitest/spy": "4.1.11",
+                "@vitest/utils": "4.1.11",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -8307,12 +8279,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.10",
-                "@vitest/browser-preview": "4.1.10",
-                "@vitest/browser-webdriverio": "4.1.10",
-                "@vitest/coverage-istanbul": "4.1.10",
-                "@vitest/coverage-v8": "4.1.10",
-                "@vitest/ui": "4.1.10",
+                "@vitest/browser-playwright": "4.1.11",
+                "@vitest/browser-preview": "4.1.11",
+                "@vitest/browser-webdriverio": "4.1.11",
+                "@vitest/coverage-istanbul": "4.1.11",
+                "@vitest/coverage-v8": "4.1.11",
+                "@vitest/ui": "4.1.11",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "cli-progress": "^3.12.0",
                 "commander": "^14.0.0",
                 "datatables.net": "^2.3.6",
-                "datatables.net-dt": "^3.0.1",
+                "datatables.net-dt": "^2.3.8",
                 "esquery": "^1.6.0",
                 "express": "^5.2.1",
                 "graphql": "^17.0.2",
@@ -3808,19 +3808,14 @@
             }
         },
         "node_modules/datatables.net-dt": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-3.0.1.tgz",
-            "integrity": "sha512-LyXZuqXslsVqS42GX6yzfCdjPjyb244iokXFjAzlPxCPyILGNKuEhz6K/a8/GKK8tGt6vOEdL12MD+nRjucoNA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-2.3.8.tgz",
+            "integrity": "sha512-GD4on0YvNlUS/l+mrXeA1OC2JDzF2/GGbehVv4AacwtiFaoTwqxZseiR0cED6w59u/lgpVrZRC2RwuubUX996Q==",
             "license": "MIT",
             "dependencies": {
-                "datatables.net": "3.0.1"
+                "datatables.net": "2.3.8",
+                "jquery": ">=1.7"
             }
-        },
-        "node_modules/datatables.net-dt/node_modules/datatables.net": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.1.tgz",
-            "integrity": "sha512-cV/2DJr42PFMnK9sAoK/QbcuE7g9HYF0x0vOND7WRsG2RWMkiyOY8TOJFbi+uDkBH4I7ggmkBvO+j4gNoh+u3g==",
-            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "2.0.1-beta.2",
+    "version": "2.0.1-beta.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@js-recon/js-recon",
-            "version": "2.0.1-beta.2",
+            "version": "2.0.1-beta.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -19,7 +19,6 @@
                 "@modelcontextprotocol/sdk": "^1.29.0",
                 "@shriyanss/cli-print-img": "^1.1.1",
                 "@shriyanss/cs-mast": "0.1.8",
-                "@types/chalk": "^0.4.31",
                 "@types/cli-progress": "^3.11.6",
                 "better-sqlite3": "^12.5.0",
                 "blessed": "^0.1.81",
@@ -2424,12 +2423,6 @@
                 "@types/deep-eql": "*",
                 "assertion-error": "^2.0.1"
             }
-        },
-        "node_modules/@types/chalk": {
-            "version": "0.4.31",
-            "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
-            "integrity": "sha512-nF0fisEPYMIyfrFgabFimsz9Lnuu9MwkNrrlATm2E4E46afKDyeelT+8bXfw1VSc7sLBxMxRgT7PxTC2JcqN4Q==",
-            "license": "MIT"
         },
         "node_modules/@types/cli-progress": {
             "version": "3.11.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "cli-progress": "^3.12.0",
                 "commander": "^14.0.0",
                 "datatables.net": "^2.3.6",
-                "datatables.net-dt": "^2.3.6",
+                "datatables.net-dt": "^3.0.1",
                 "esquery": "^1.6.0",
                 "express": "^5.2.1",
                 "graphql": "^17.0.2",
@@ -3880,14 +3880,19 @@
             }
         },
         "node_modules/datatables.net-dt": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-2.3.8.tgz",
-            "integrity": "sha512-GD4on0YvNlUS/l+mrXeA1OC2JDzF2/GGbehVv4AacwtiFaoTwqxZseiR0cED6w59u/lgpVrZRC2RwuubUX996Q==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-3.0.1.tgz",
+            "integrity": "sha512-LyXZuqXslsVqS42GX6yzfCdjPjyb244iokXFjAzlPxCPyILGNKuEhz6K/a8/GKK8tGt6vOEdL12MD+nRjucoNA==",
             "license": "MIT",
             "dependencies": {
-                "datatables.net": "2.3.8",
-                "jquery": ">=1.7"
+                "datatables.net": "3.0.1"
             }
+        },
+        "node_modules/datatables.net-dt/node_modules/datatables.net": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.1.tgz",
+            "integrity": "sha512-cV/2DJr42PFMnK9sAoK/QbcuE7g9HYF0x0vOND7WRsG2RWMkiyOY8TOJFbi+uDkBH4I7ggmkBvO+j4gNoh+u3g==",
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "express": "^5.2.1",
                 "graphql": "^17.0.2",
                 "highlight.js": "^11.11.1",
-                "inquirer": "^12.6.3",
+                "inquirer": "^14.0.2",
                 "marked": "^16.1.2",
                 "md5": "^2.3.0",
                 "ohash": "^2.0.11",
@@ -813,28 +813,27 @@
             }
         },
         "node_modules/@inquirer/ansi": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-            "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+            "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             }
         },
         "node_modules/@inquirer/checkbox": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
-            "integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+            "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -846,16 +845,16 @@
             }
         },
         "node_modules/@inquirer/confirm": {
-            "version": "5.1.14",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-            "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+            "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -867,22 +866,21 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-            "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+            "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.2",
-                "@inquirer/figures": "^1.0.15",
-                "@inquirer/type": "^3.0.10",
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7",
                 "cli-width": "^4.1.0",
-                "mute-stream": "^2.0.0",
-                "signal-exit": "^4.1.0",
-                "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.3"
+                "fast-wrap-ansi": "^0.2.0",
+                "mute-stream": "^3.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -894,17 +892,17 @@
             }
         },
         "node_modules/@inquirer/editor": {
-            "version": "4.2.23",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-            "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+            "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.2",
-                "@inquirer/external-editor": "^1.0.3",
-                "@inquirer/type": "^3.0.10"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/external-editor": "^3.0.3",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -916,17 +914,16 @@
             }
         },
         "node_modules/@inquirer/expand": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-            "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+            "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -938,16 +935,16 @@
             }
         },
         "node_modules/@inquirer/external-editor": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
             "license": "MIT",
             "dependencies": {
                 "chardet": "^2.1.1",
-                "iconv-lite": "^0.7.0"
+                "iconv-lite": "^0.7.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -959,9 +956,9 @@
             }
         },
         "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -975,25 +972,25 @@
             }
         },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+            "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             }
         },
         "node_modules/@inquirer/input": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-            "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+            "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1005,16 +1002,16 @@
             }
         },
         "node_modules/@inquirer/number": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-            "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+            "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1026,17 +1023,17 @@
             }
         },
         "node_modules/@inquirer/password": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-            "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+            "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2"
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1048,24 +1045,24 @@
             }
         },
         "node_modules/@inquirer/prompts": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.0.tgz",
-            "integrity": "sha512-JHwGbQ6wjf1dxxnalDYpZwZxUEosT+6CPGD9Zh4sm9WXdtUp9XODCQD3NjSTmu+0OAyxWXNOqf0spjIymJa2Tw==",
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+            "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/checkbox": "^4.2.0",
-                "@inquirer/confirm": "^5.1.14",
-                "@inquirer/editor": "^4.2.15",
-                "@inquirer/expand": "^4.0.17",
-                "@inquirer/input": "^4.2.1",
-                "@inquirer/number": "^3.0.17",
-                "@inquirer/password": "^4.0.17",
-                "@inquirer/rawlist": "^4.1.5",
-                "@inquirer/search": "^3.1.0",
-                "@inquirer/select": "^4.3.1"
+                "@inquirer/checkbox": "^5.2.1",
+                "@inquirer/confirm": "^6.1.1",
+                "@inquirer/editor": "^5.2.2",
+                "@inquirer/expand": "^5.1.1",
+                "@inquirer/input": "^5.1.2",
+                "@inquirer/number": "^4.1.1",
+                "@inquirer/password": "^5.1.1",
+                "@inquirer/rawlist": "^5.3.1",
+                "@inquirer/search": "^4.2.1",
+                "@inquirer/select": "^5.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1077,17 +1074,16 @@
             }
         },
         "node_modules/@inquirer/rawlist": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-            "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+            "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1099,18 +1095,17 @@
             }
         },
         "node_modules/@inquirer/search": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
-            "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+            "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1122,19 +1117,18 @@
             }
         },
         "node_modules/@inquirer/select": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-            "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+            "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1146,12 +1140,12 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-            "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+            "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -3116,21 +3110,6 @@
                 }
             }
         },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3495,9 +3474,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+            "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
             "license": "MIT"
         },
         "node_modules/charenc": {
@@ -4555,6 +4534,21 @@
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
             "license": "Unlicense"
         },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "license": "MIT"
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-truncated-width": "^3.0.2"
+            }
+        },
         "node_modules/fast-uri": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -4570,6 +4564,15 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-wrap-ansi": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+            "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-width": "^3.0.2"
+            }
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -5130,21 +5133,20 @@
             "license": "ISC"
         },
         "node_modules/inquirer": {
-            "version": "12.9.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.0.tgz",
-            "integrity": "sha512-LlFVmvWVCun7uEgPB3vups9NzBrjJn48kRNtFGw3xU1H5UXExTEz/oF1JGLaB0fvlkUB+W6JfgLcSEaSdH7RPA==",
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+            "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/prompts": "^7.8.0",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "mute-stream": "^2.0.0",
-                "run-async": "^4.0.5",
-                "rxjs": "^7.8.2"
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/prompts": "^8.5.2",
+                "@inquirer/type": "^4.0.7",
+                "mute-stream": "^3.0.0",
+                "run-async": "^4.0.6"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -6185,12 +6187,12 @@
             "license": "MIT"
         },
         "node_modules/mute-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+            "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
             "license": "ISC",
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/mz": {
@@ -7248,21 +7250,12 @@
             }
         },
         "node_modules/run-async": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
-            "integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+            "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/rxjs": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-buffer": {
@@ -8006,18 +7999,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/type-is": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -8431,20 +8412,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8578,18 +8545,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yoctocolors-cjs": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "express": "^5.2.1",
         "graphql": "^17.0.2",
         "highlight.js": "^11.11.1",
-        "inquirer": "^12.6.3",
+        "inquirer": "^14.0.2",
         "marked": "^16.1.2",
         "md5": "^2.3.0",
         "ohash": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "2.0.1-beta.2",
+    "version": "2.0.1-beta.3",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@shriyanss/cli-print-img": "^1.1.1",
         "@shriyanss/cs-mast": "0.1.8",
-        "@types/chalk": "^0.4.31",
         "@types/cli-progress": "^3.11.6",
         "better-sqlite3": "^12.5.0",
         "blessed": "^0.1.81",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "cli-progress": "^3.12.0",
         "commander": "^14.0.0",
         "datatables.net": "^2.3.6",
-        "datatables.net-dt": "^2.3.6",
+        "datatables.net-dt": "^3.0.1",
         "esquery": "^1.6.0",
         "express": "^5.2.1",
         "graphql": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "cli-progress": "^3.12.0",
         "commander": "^14.0.0",
         "datatables.net": "^2.3.6",
-        "datatables.net-dt": "^3.0.1",
+        "datatables.net-dt": "^2.3.8",
         "esquery": "^1.6.0",
         "express": "^5.2.1",
         "graphql": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "author": "Shriyans Sudhi",
     "license": "MIT",
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.117.1",
+        "@anthropic-ai/sdk": "^0.122.0",
         "@aws-sdk/client-api-gateway": "^3.958.0",
         "@babel/generator": "^8.0.0",
         "@babel/parser": "^8.0.4",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/js-recon/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "2.0.1-beta.2";
+const version = "2.0.1-beta.3";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/lazyLoad/sourcemap.ts
+++ b/src/lazyLoad/sourcemap.ts
@@ -228,31 +228,6 @@ function normalizePath(path: string): string {
 }
 
 /**
- * Sanitize a path to ensure it cannot escape the output directory.
- * This is a safety check that should be used before writing files.
- *
- * @param basePath - The base output directory (absolute path)
- * @param filePath - The file path to sanitize
- * @returns Safe path that is guaranteed to be under basePath
- */
-export function safePath(basePath: string, filePath: string): string {
-    // Clean and normalize the file path
-    let cleaned = cleanPath(filePath);
-    cleaned = normalizePath(cleaned);
-
-    // Remove any remaining ../ sequences (belt and suspenders)
-    cleaned = cleaned.replace(/\.\.\//g, "").replace(/^\.\.$/, "");
-
-    // Remove leading slashes to prevent absolute path injection
-    cleaned = cleaned.replace(/^\/+/, "");
-
-    // Join with base path
-    const joined = basePath.endsWith("/") ? basePath + cleaned : basePath + "/" + cleaned;
-
-    return joined;
-}
-
-/**
  * Join two path segments
  */
 function joinPaths(base: string, path: string): string {


### PR DESCRIPTION
## 2.0.1-beta.3 - 2026-09-03

### Changed

- Bumped dependencies via Dependabot: `puppeteer`/`puppeteer-core` (Docker images, #179), the `actions/*` GitHub Actions group (#181), the npm minor/patch group covering 10 packages (#182), `inquirer` to 14.0.2 (#176), and `datatables.net-dt` to 3.0.1 (#175).
- Removed the `@types/chalk` dev dependency — it's a deprecated stub package superseded by `chalk`'s own bundled type definitions (unused since the `chalk` v6 bump); nothing in `src/` referenced it (#177, closed instead of merged).

### Security

- Removed `safePath()` from `src/lazyLoad/sourcemap.ts`, an unused path-sanitization function whose single-pass `../` regex strip could leave a traversal sequence behind (CodeQL `js/incomplete-multi-character-sanitization`). The function had no callers anywhere in the codebase; the actual source-map output write path is already bounded correctly by `resolveSourceMapOutputPath()` in `src/sourcemaps/index.ts`. (`lazyload`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 2.0.1-beta.3.
  * Updated the underlying browser runtime and supporting components for improved compatibility.

* **Security**
  * Improved source map output path handling to better prevent unsafe path traversal.

* **Maintenance**
  * Updated automated security analysis and release tooling.
  * Refreshed dependency versions and removed an obsolete type package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->